### PR TITLE
return all valid reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.29.1",
     "rimraf": "^5.0.5",
-    "rollup": "^4.14.1",
+    "rollup": "^4.24.0",
     "rollup-plugin-typescript2": "^0.36.0",
     "typescript": "^5.2.2"
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -259,14 +259,14 @@ export default class OracleClient {
 
     let jsonBody;
     try {
-      jsonBody = await response.json() as { validReports: number[]; errorMessages?: string[] };
+      jsonBody = await response.json() as { validReports: number[]; errorMessage?: string };
     } catch (e) {
       this.log(`OracleClient: failed to parse verification response from ${this.#verifier}, reason - ${e}`);
       throw new Error('verification failed', { cause: { host: this.#verifier, status: response.statusText } });
     }
 
     if (jsonBody.validReports.length === 0) {
-      throw new AttestationIntegrityError(`verification failed for all reports: ${jsonBody.errorMessages}`);
+      throw new AttestationIntegrityError(`verification failed for all reports: ${jsonBody.errorMessage}`);
     }
 
     const validAttestations = attestations.filter((_, index) => jsonBody.validReports.includes(index));

--- a/src/request.ts
+++ b/src/request.ts
@@ -32,10 +32,8 @@ export async function resolveBackends(backends: Required<CustomBackendConfig>[],
 
 // Performs a request to the backend mesh prepared by resolveBackends
 // eslint-disable-next-line max-len
-export async function requestBackendMesh(backendMesh: BackendMesh, method: string, body?: object, abortSignal?: AbortSignal): Promise<Response[]> {
-  // each backend may be resolved to more than one IP, send a request to all of them,
-  // for every backend wait for only one response to arrive.
-  return Promise.all(
+export async function requestBackendMesh(backendMesh: BackendMesh, method: string, body?: object, abortSignal?: AbortSignal): Promise<PromiseSettledResult<Response>[]> {
+  return Promise.allSettled(
     backendMesh.map(async (resolvedBackend) => {
       const fetchOptions: RequestInit = {
         ...resolvedBackend.backend.init,
@@ -48,6 +46,8 @@ export async function requestBackendMesh(backendMesh: BackendMesh, method: strin
         },
       };
 
+      // each backend may be resolved to more than one IP, send a request to all of them,
+      // for every backend wait for only one response to arrive.
       return Promise.any(
         resolvedBackend.ipAndUrl.map(({ ip, path }) => fetch(resolvedBackend.backend, ip, path, fetchOptions)),
       );


### PR DESCRIPTION
- Return all reports that were successfully created instead of throwing an error if one of the backends has not responded due to networking issues (one successful reply is enough when multiple backends are used)
- Bump rollup version (npm audit fix)