### PR TITLE
fix crash if validReports is not present in verification response

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -265,7 +265,7 @@ export default class OracleClient {
       throw new Error('verification failed', { cause: { host: this.#verifier, status: response.statusText } });
     }
 
-    if (jsonBody.validReports.length === 0) {
+    if (!jsonBody.validReports || jsonBody.validReports.length === 0) {
       throw new AttestationIntegrityError(`verification failed for all reports: ${jsonBody.errorMessage}`);
     }
 


### PR DESCRIPTION
validReports array is not present in the old verification backend versions